### PR TITLE
Avoid calling fclose twice

### DIFF
--- a/src/asynch_interface.c
+++ b/src/asynch_interface.c
@@ -438,9 +438,11 @@ void Asynch_Free(AsynchSolver* asynch)
         ConnData_Free(&asynch->db_connections[i]);
     Destroy_Workspace(&asynch->workspace, asynch->globals->max_rk_stages, asynch->globals->max_parents);
     free(asynch->getting);
-    
-    if (asynch->outputfile)
+
+    if (asynch->outputfile != NULL) {
         fclose(asynch->outputfile);
+        asynch->outputfile = NULL;
+    }
 
     for (i = 0; i < asynch->N; i++)
         Destroy_Link(&asynch->sys[i], asynch->rkdfilename[0] != '\0', asynch->forcings, asynch->globals);
@@ -1074,8 +1076,10 @@ int Asynch_Check_Peakflow_Output(AsynchSolver* asynch, char* name)
 
 int Asynch_Delete_Temporary_Files(AsynchSolver* asynch)
 {
-    if (asynch->outputfile)
+    if (asynch->outputfile != NULL) {
         fclose(asynch->outputfile);
+        asynch->outputfile = NULL;
+    }
 
     int ret_val = RemoveTemporaryFiles(asynch->globals, asynch->my_save_size, NULL);
     //if(ret_val == 1)	printf("[%i]: Error deleting temp file. File does not exist.\n");


### PR DESCRIPTION
### Fix
Avoid calling fclose(asynch->outputfile) twice on src/asynch_interface.c

This is Undefined Behavior.

See ISO/IEC TS 17961:2013(E) Table B.1 (Undefined behaviors):
`(153) The value of a pointer to a FILE object is used after the associated file is closed (7.23.3).`

### Before
Program crashed after writing the outputs

	Computations complete. Total time for calculations: 0.805469

	Results written to file clearcreek.h5.
	Peakflows written to file clearcreek.pea.
	free(): double free detected in tcache 2
	free(): double free detected in tcache 2
	[pop-os:21091] *** Process received signal ***
	[pop-os:21091] Signal: Aborted (6)
	[pop-os:21091] Signal code:  (-6)
	[pop-os:21090] *** Process received signal ***
	[pop-os:21090] Signal: Aborted (6)
	[pop-os:21090] Signal code:  (-6)
	[pop-os:21091] [ 0] [pop-os:21090] [ 0] /lib/x86_64-linux-gnu/libc.so.6(+0x45330)[0x7f7012e45330]
	[pop-os:21091] [ 1] /lib/x86_64-linux-gnu/libc.so.6(+0x45330)[0x7104bc245330]
	[pop-os:21090] [ 1] /lib/x86_64-linux-gnu/libc.so.6(pthread_kill+0x11c)[0x7f7012e9eb2c]
	[pop-os:21091] [ 2] /lib/x86_64-linux-gnu/libc.so.6(pthread_kill+0x11c)[0x7104bc29eb2c]
	[pop-os:21090] [ 2] /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x1e)[0x7f7012e4527e]
	[pop-os:21091] /lib/x86_64-linux-gnu/libc.so.6(gsignal+0x1e)[0x7104bc24527e]
	[pop-os:21090] [ 3] [ 3] /lib/x86_64-linux-gnu/libc.so.6(abort+0xdf)[0x7f7012e288ff]
	[pop-os:21091] [ 4] /lib/x86_64-linux-gnu/libc.so.6(abort+0xdf)[0x7104bc2288ff]
	[pop-os:21090] [ 4] /lib/x86_64-linux-gnu/libc.so.6(+0x297b6)[0x7104bc2297b6]
	[pop-os:21090] [ 5] /lib/x86_64-linux-gnu/libc.so.6(+0x297b6)[0x7f7012e297b6]
	[pop-os:21091] [ 5] /lib/x86_64-linux-gnu/libc.so.6(+0xa8ff5)[0x7104bc2a8ff5]
	[pop-os:21090] [ 6] /lib/x86_64-linux-gnu/libc.so.6(+0xa8ff5)[0x7f7012ea8ff5]
	[pop-os:21091] [ 6] /lib/x86_64-linux-gnu/libc.so.6(+0xab55f)[0x7104bc2ab55f]
	[pop-os:21090] [ 7] /lib/x86_64-linux-gnu/libc.so.6(+0xab55f)[0x7f7012eab55f]
	[pop-os:21091] [ 7] /lib/x86_64-linux-gnu/libc.so.6(__libc_free+0x7e)[0x7f7012eaddae]
	[pop-os:21091] [ 8] /lib/x86_64-linux-gnu/libc.so.6(__libc_free+0x7e)[0x7104bc2addae]
	[pop-os:21090] [ 8] /lib/x86_64-linux-gnu/libc.so.6(_IO_fclose+0xa0)[0x7104bc285330]
	[pop-os:21090] [ 9] ../build/src/asynch(+0x72dd)[0x5a452dd312dd]
	[pop-os:21090] [10] ../build/src/asynch(+0x562e)[0x5a452dd2f62e]
	[pop-os:21090] [11] /lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7104bc22a1ca]
	[pop-os:21090] [12] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7104bc22a28b]
	[pop-os:21090] [13] ../build/src/asynch(+0x5b35)[0x5a452dd2fb35]
	[pop-os:21090] *** End of error message ***
	/lib/x86_64-linux-gnu/libc.so.6(_IO_fclose+0xa0)[0x7f7012e85330]
	[pop-os:21091] [ 9] ../build/src/asynch(+0x72dd)[0x56fab43182dd]
	[pop-os:21091] [10] ../build/src/asynch(+0x562e)[0x56fab431662e]
	[pop-os:21091] [11] /lib/x86_64-linux-gnu/libc.so.6(+0x2a1ca)[0x7f7012e2a1ca]
	[pop-os:21091] [12] /lib/x86_64-linux-gnu/libc.so.6(__libc_start_main+0x8b)[0x7f7012e2a28b]
	[pop-os:21091] [13] ../build/src/asynch(+0x5b35)[0x56fab4316b35]
	[pop-os:21091] *** End of error message ***
	--------	------------------------------------------------------------------
	Primary job  terminated normally, but 1 process returned
	a non-zero exit code. Per user-direction, the job has been aborted.
	--------------------------------------------------------------------------
	--------------------------------------------------------------------------
	mpirun noticed that process rank 0 with PID 0 on node pop-os exited on signal 6 (Aborted).
	--------------------------------------------------------------------------

### After
Program terminates cleanly.

	Computations complete. Total time for calculations: 0.845286

	Results written to file clearcreek.h5.
	Peakflows written to file clearcreek.pea.